### PR TITLE
Added iproute2 dependency to Puppet

### DIFF
--- a/puppet/Dockerfile
+++ b/puppet/Dockerfile
@@ -11,7 +11,7 @@ RUN echo deb http://deb.theforeman.org/ xenial $FOREMAN_VERSION > /etc/apt/sourc
   && echo deb http://deb.theforeman.org/ plugins $FOREMAN_VERSION >> /etc/apt/sources.list.d/foreman.list \
   && wget -q https://deb.theforeman.org/pubkey.gpg -O- | apt-key add - \ 
   && apt-get update \
-  && apt-get install -y foreman-proxy netcat nscd
+  && apt-get install -y foreman-proxy netcat nscd iproute2
 
 # enable foreman-proxy 
 RUN sed -i '/:enabled/c\:enabled: https' /etc/foreman-proxy/settings.d/puppet.yml 


### PR DESCRIPTION
Removed .configured file from repo - post_config doesn't run if it's there.  It creates its own after a successful run.
Note that puppet's certs need to be generated manually otherwise Puppet won't startup.
as per docs:
docker run -v /opt/foreman/volumes/puppet/ssl:/etc/puppetlabs/puppet/ssl puppet/puppet-agent cert --generate YOUR_HOSTNAME.  It might be useful to add some script logic to run this automatically, i'll look into it once the baseline stability is functional.